### PR TITLE
Bugfix/Fixed build do to file name error

### DIFF
--- a/projects/Qt5.cmake
+++ b/projects/Qt5.cmake
@@ -165,7 +165,7 @@ else()
 
   set(QT5_ONLINE_INSTALLER "${EMsoft_SDK}/superbuild/${extProjectName}/Download/${qt5_online_installer}")
   configure_file(
-    "${_self_dir}/unix/Qt5_linux_install.sh.in"
+    "${_self_dir}/unix/Qt5_Linux_install.sh.in"
     "${EMsoft_SDK}/superbuild/${extProjectName}/Download/Qt_HeadlessInstall.sh"
   )
 


### PR DESCRIPTION
Qt5 Cmake build was broken in a hard-to-spot way: a letter was lowercase when it needed to be capitalized. This fixes the build. 
Tested on Ubuntu 16.04 LTS.