### PR TITLE
Remove nested include

### DIFF
--- a/projects/JsonFortran.cmake
+++ b/projects/JsonFortran.cmake
@@ -4,7 +4,7 @@ message(STATUS "External Project: ${extProjectName}" )
 set(JSONFORTRAN_VERSION "4.2.1")
 
 # This is need to figure out the proper install dir for some Linux distributions
-include(include(GNUInstallDirs))
+include(GNUInstallDirs)
 
 if(MSVC_IDE)
   set(JSONFORTRAN_INSTALL "${EMsoft_SDK}/${extProjectName}-${JSONFORTRAN_VERSION}")


### PR DESCRIPTION
I know little about CMake... but this nested include statement in `Jsonfortran.cmake`

```bash
# This is need to figure out the proper install dir for some Linux distributions
include(include(GNUInstallDirs))
```

yields this

```bash
-- External Project: jsonfortran
CMake Error at projects/JsonFortran.cmake:7 (include):
  include called with invalid argument: GNUInstallDirs
Call Stack (most recent call first):
  CMakeLists.txt:176 (include)
```

Builds fine without the nested `include`. Thus this tiny PR.

Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>