### PR TITLE
Update to support Mac OS Big Sur and gfortran 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ if(APPLE)
     set(OSX_SDK "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
   ENDIF ()
 
+  IF (DARWIN_VERSION EQUAL 20) # macOS 11.0 Big Sur (Xcode 11.x)
+    message(STATUS "Found macOS 11.0 big sur as the host. Darwin Version:${DARWIN_VERSION}")
+    set(OSX_SDK "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
+  ENDIF ()
+
   if("${OSX_SDK}" STREQUAL "NOT-FOUND")
     message(FATAL_ERROR "This version of macOS (${DARWIN_VERSION}) is not recognized.\
     The following versions are supported:\n\
@@ -124,6 +129,7 @@ if(APPLE)
     (17) macOS 10.13 High Sierra\n\
     (18) macOS 10.14 Mojave\n\
     (19) macOS 10.15 Catalina\n\
+    (20) macOS 11.00 Big Sur\n\
     Please edit ${CMAKE_CURRENT_LIST_FILE} and add this version of macOS to the detection logic.
     ")
 

--- a/projects/CLFortran.cmake
+++ b/projects/CLFortran.cmake
@@ -47,6 +47,11 @@ else()
   endif()
 endif()
 
+if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER 9.9)
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz")
+  message(STATUS "Adjusting CMAKE_Fortran_FLAGS for gfortran-10 compatibility: '${CMAKE_Fortran_FLAGS}'")
+endif()
+
 ExternalProject_Add(${extProjectName}
   #DOWNLOAD_NAME ${extProjectName}-${CLFortran_VERSION}.tar.gz
   #URL ${CLFortran_URL}
@@ -65,6 +70,7 @@ ExternalProject_Add(${extProjectName}
     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_DEPLOYMENT_TARGET}
     -DCMAKE_OSX_SYSROOT=${OSX_SDK}
+    -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
     -DOpenCL_INCLUDE_DIR:PATH=${OpenCL_INCLUDE_DIR}
     -DOpenCL_LIBRARY:FILEPATH=${OpenCL_LIBRARY}
 

--- a/projects/HDF5.cmake
+++ b/projects/HDF5.cmake
@@ -1,10 +1,11 @@
 set(extProjectName "hdf5")
 
-set(HDF5_VERSION "1.10.5")
+set(HDF5_VERSION "1.10.7")
 message(STATUS "External Project: ${extProjectName}: ${HDF5_VERSION}" )
 
 #set(HDF5_URL "http://www.hdfgroup.org/ftp/HDF5/prev-releases/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz")
-set(HDF5_URL "http://dream3d.bluequartz.net/binaries/SDK/Sources/HDF5/hdf5-${HDF5_VERSION}.tar.gz")
+#set(HDF5_URL "http://dream3d.bluequartz.net/binaries/SDK/Sources/HDF5/hdf5-${HDF5_VERSION}.tar.gz")
+set(HDF5_URL "https://support.hdfgroup.org/ftp/HDF5/prev-releases/hdf5-1.10/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz")
 
 set(HDF5_BUILD_SHARED_LIBS ON)
 set(HDF5_INSTALL "${EMsoft_SDK}/${extProjectName}-${HDF5_VERSION}-${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
A few minor updates to :

1. make the support of Mac OS X Big Sur (version 20) official
2. add automatically compilation flags for gfortran 10 to ignore invalid BOZ literals
3. update to HDF version 1.10.7 to address implicit function declaration issues when compiling with C99 standard